### PR TITLE
handle atoms as strings to match ruby implementation

### DIFF
--- a/lib/notation.ex
+++ b/lib/notation.ex
@@ -15,13 +15,15 @@ defmodule Notation do
 
   def notate(data) when is_map(data), do: sort_map(data) <> "H"
 
+  def notate(data) when is_atom(data), do: Atom.to_string(data) |> notate()
+
   defp sort_list(list) do
     list
     |> Enum.sort(&string_compare/2)
     |> Enum.map(&notate/1)
     |> to_string
   end
-  
+
   defp sort_map(map) do
     map
     |> tuple()

--- a/test/notation_test.exs
+++ b/test/notation_test.exs
@@ -33,6 +33,14 @@ defmodule NotationTest do
     test "when passed a nested list it will sort it" do
       assert Notation.notate([3, [4, 2], 1]) == "1N3N2N4NAA"
     end
+
+    test "atoms are treated as strings" do
+      assert Notation.notate(:a) == Notation.notate("a")
+    end
+
+    test "atoms are case sensitive" do
+      refute Notation.notate(:A) == Notation.notate("a")
+    end
   end
 
   describe "acceptance tests" do


### PR DESCRIPTION
The ruby implementation handles symbols as strings. So this is [to match the ruby implementation](https://github.com/BBC-News/crimp#symbols)