### PR TITLE
Fix notation implementation to pass failing acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Under the hood Crimpex annotates the passed data structure to a nested array of 
 You can verify it using the `#notation` function:
 
 ```elixir
-Notation.notate({a=1})
+Notation.notate(%{a: 1})
 "1NaSAH"
 ```
 
 Before signing Crimpex, uses the `#notation` function to transform the return value of a map to a string.
 
 ```elixir
-Notation.notate({ a: { b: 'c' } })
+Notation.notate(%{ a: %{ b: "c" } })
 "aSbScSAHAH"
 ```
 
@@ -92,25 +92,6 @@ For testing we use ExUnit built into Elixir itself
 
 ```sh
 mix test
-```
-
-## Caveats
-
-Currently this implementation of Crimp does not cover the functionallity that the original project intended, there is an issue with the Notation of Nested Hashes/Maps meaning they get sorted seperately causing the Signature to be incorrect. We are working to fix this and hopefully will update the project soon with that functionality.
-
-Below is the test output from both the notation and the signature methods, the left side is what we receive from our function, the right side is what we expect to receive as per the guidelines in the Ruby Gems acceptance tests found here: https://github.com/BBC-News/crimp/blob/master/spec/acceptance_data.yml
-
-Test output from the Notation function:
-```
-  code:  assert Notation.notate(%{"a" => %{"c" => nil, "2" => 2}}) == "aS2S2NA_cSAHAH"
-  left:  "_cSA2S2NAHaSAH"
-  right: "aS2S2NA_cSAHAH"
-```
-Test output from the Signature function:
-```
-  code:  assert Crimpex.signature(%{"a" => %{"c" => nil, "2" => 2}}) == "bff3538075e4007c7679a7ba0d0a5f30"
-  left:  "97f769660fb74bbad88419afd8423b99"
-  right: "bff3538075e4007c7679a7ba0d0a5f30"
 ```
 
 The project has also not been pushed to Hex as of yet so will need to be added as a git dependency.

--- a/lib/notation.ex
+++ b/lib/notation.ex
@@ -13,7 +13,12 @@ defmodule Notation do
 
   def notate(data) when is_list(data), do: sort_list(data) <> "A"
 
-  def notate(data) when is_map(data), do: sort_map(data) <> "H"
+  def notate(data) when is_map(data) do
+    [Enum.map(data, &notate(&1)) | "H"] |> IO.iodata_to_binary()
+  end
+
+  def notate({k, v}) when is_map(v), do: [notate(k), notate(v), "A"]
+  def notate({k, v}), do: notate([k, v])
 
   def notate(data) when is_atom(data), do: Atom.to_string(data) |> notate()
 
@@ -22,21 +27,6 @@ defmodule Notation do
     |> Enum.sort(&string_compare/2)
     |> Enum.map(&notate/1)
     |> :erlang.list_to_binary
-  end
-
-  defp sort_map(map) do
-    map
-    |> tuple()
-    |> Enum.sort(&string_compare/2)
-    |> Enum.map(&notate/1)
-    |> :erlang.list_to_binary
-  end
-
-  defp tuple(map) do
-    map
-    |> Enum.map(fn {k, v} ->
-      [to_string(k), v]
-    end)
   end
 
   defp string_compare(nil, _) do
@@ -55,13 +45,5 @@ defmodule Notation do
     a <= to_string(b)
   end
 
-  defp string_compare(a, b) do
-    compare_objects(a) <= compare_objects(b)
-  end
-
-  defp compare_objects(obj) when is_list(obj), do: Enum.sort(obj, &string_compare/2)
-
-  defp compare_objects(obj) when is_map(obj), do: Enum.sort(tuple(obj), &string_compare/2)
-
-  defp compare_objects(obj) when not is_list(obj) or is_map(obj), do: obj
+  defp string_compare(a, b), do: a < b
 end

--- a/test/crimpex_test.exs
+++ b/test/crimpex_test.exs
@@ -55,12 +55,9 @@ defmodule CrimpexTest do
       assert Crimpex.signature(%{"a" => 1}) == "8cb44d69badda0f34b0bab6bb3e7fdbf"
     end
 
-    # This fails on master!
-    # This acceptance test is taken from the original ruby implementation
-    # This test failing means this Elixir implementation does not completely match.
-#    test "verify nested hash" do
-#      assert Crimpex.signature(%{"a" => %{"c" => nil, "2" => 2 }}) == "bff3538075e4007c7679a7ba0d0a5f30"
-#    end
+    test "verify nested hash" do
+      assert Crimpex.signature(%{"a" => %{"c" => nil, "2" => 2 }}) == "bff3538075e4007c7679a7ba0d0a5f30"
+    end
 
     test "verify null values" do
       assert Crimpex.signature(nil) == "b14a7b8059d9c055954c92674ce60032"

--- a/test/notation_test.exs
+++ b/test/notation_test.exs
@@ -84,12 +84,9 @@ defmodule NotationTest do
       assert Notation.notate(%{"a" => 1}) == "1NaSAH"
     end
 
-    # This fails on master!
-    # This acceptance test is taken from the original ruby implementation
-    # This test failing means this Elixir implementation does not completely match.
-#    test "verify nested hash" do
-#      assert Notation.notate(%{"a" => %{"c" => nil, "2" => 2 }}) == "aS2S2NA_cSAHAH"
-#    end
+    test "verify nested hash" do
+     assert Notation.notate(%{"a" => %{"c" => nil, "2" => 2 }}) == "aS2S2NA_cSAHAH"
+    end
 
     test "verify null values" do
       assert Notation.notate(nil) == "_"


### PR DESCRIPTION
Related to: https://github.com/BBC-News/crimpex/pull/4

Elixir Map already intrinsically sort tuples in a way that's corresponding to the [Crimp](https://github.com/BBC-News/crimp) spec, e.g.:

```
iex(1)> %{"r" => 1, "R" => 1, "2" => 1, "A" => 1, 1 => 1, "1" => 1}
%{1 => 1, "1" => 1, "2" => 1, "A" => 1, "R" => 1, "r" => 1}
```

There is no need to re-sort Map data (as in the current implementation that isn't working). All it needs to pass the acceptance tests is, to simply encode map's tuples accordingly and recursively as shown in this PR.

This also enables us to get rid of `Enum.map` based functions (`sort_map`, `tuples`), and the layers of `compare_objects` sorting functions. This should make the Notation module leaner.

