### PR TITLE
Add map sorting functionality

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/notation.ex
+++ b/lib/notation.ex
@@ -14,7 +14,13 @@ defmodule Notation do
   def notate(data) when is_list(data), do: sort_list(data) <> "A"
 
   def notate(data) when is_map(data) do
-    [Enum.map(data, &notate(&1)) | "H"] |> IO.iodata_to_binary()
+    [
+      :maps.to_list(data)
+      |> Enum.sort()
+      |> Enum.map(&notate/1)
+      | "H"
+    ]
+    |> IO.iodata_to_binary()
   end
 
   def notate({k, v}) when is_map(v), do: [notate(k), notate(v), "A"]
@@ -26,7 +32,7 @@ defmodule Notation do
     list
     |> Enum.sort(&string_compare/2)
     |> Enum.map(&notate/1)
-    |> :erlang.list_to_binary
+    |> :erlang.list_to_binary()
   end
 
   defp string_compare(nil, _) do
@@ -43,6 +49,10 @@ defmodule Notation do
 
   defp string_compare(a, b) when is_bitstring(a) and is_number(b) do
     a <= to_string(b)
+  end
+
+  defp string_compare(a, b) when is_atom(a) do
+    to_string(a) <= b
   end
 
   defp string_compare(a, b), do: a < b

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Crimpex.MixProject do
   def project do
     [
       app: :crimpex,
-      version: "0.1.1",
-      elixir: "~> 1.8",
+      version: "0.2.0",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/test/notation_test.exs
+++ b/test/notation_test.exs
@@ -35,6 +35,22 @@ defmodule NotationTest do
       assert Notation.notate(%{a: 1}) == "1NaSAH"
     end
 
+    test "when passed a map with multiple unsorted keys it returns with an H suffix and sorted" do
+      assert Notation.notate(%{a: 1, d: 3, b: 2}) == "1NaSA2NbSA3NdSAH"
+    end
+
+    test "when passed a nested map with multiple unsorted keys it returns with an H suffix and sorted for all levels" do
+      assert Notation.notate(%{a: 1, d: %{e: 1, g: 2, f: 3}, b: 2}) == "1NaSA2NbSAdS1NeSA3NfSA2NgSAHAH"
+    end
+
+    test "when passed a map with nested lists and maps" do
+      assert Notation.notate(%{a: [1, 2], b: %{c: "d"}}) == "1N2NAaSAbScSdSAHAH"
+    end
+
+    test "when passed a list of maps" do
+      assert Notation.notate([%{a: 1}, %{b: 2}]) == "1NaSAH2NbSAHA"
+    end
+
     test "when passed a nested list it will sort it" do
       assert Notation.notate([3, [4, 2], 1]) == "1N3N2N4NAA"
     end


### PR DESCRIPTION
In Erlang OTP 26 this now uses unsorted maps. Previously the map keys were sorted alphabetically. Crimpex guarantees the ordering of data structures to provide a consistent notation and hashing of this. Potentially we should look at ordered sets, but maps seem fundamental to the language and other languages have ordered and unordered ones.

This PR converts a map to a list and sorts this. It treats it as though it is a map by appending "H" instead of "A" for a (hash)map. It also applies sorting for atoms to get a particular order with nested data structures.

It also supports elixir 1.16 by importing the config module to remove the warning.