### PR TITLE
Fix the atom ordering

### DIFF
--- a/lib/notation.ex
+++ b/lib/notation.ex
@@ -51,7 +51,7 @@ defmodule Notation do
     a <= to_string(b)
   end
 
-  defp string_compare(a, b) when is_atom(a) do
+  defp string_compare(a, b) when is_atom(a) and is_list(b) do
     to_string(a) <= b
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Crimpex.MixProject do
   def project do
     [
       app: :crimpex,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/notation_test.exs
+++ b/test/notation_test.exs
@@ -47,6 +47,10 @@ defmodule NotationTest do
       assert Notation.notate(%{a: [1, 2], b: %{c: "d"}}) == "1N2NAaSAbScSdSAHAH"
     end
 
+    test "when passed a map with a non-list value for atom keys" do
+      assert Notation.notate(%{c?: false, method: "GET", path: "/"}) == "c?SfalseBAmethodSGETSApathS/SAH"
+    end
+
     test "when passed a list of maps" do
       assert Notation.notate([%{a: 1}, %{b: 2}]) == "1NaSAH2NbSAHA"
     end


### PR DESCRIPTION
This fixes the sorting logic which was added in https://github.com/bbc/crimpex/pull/6. The atom ordering was key first and a fix was added for lists previously. For non-lists, this PR allows them to be ordered as expected.